### PR TITLE
ValidatorExpressionEvaluationContext type-parameter S removed

### DIFF
--- a/src/main/java/walkingkooka/validation/function/FakeValidatorExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/validation/function/FakeValidatorExpressionEvaluationContext.java
@@ -25,14 +25,14 @@ import walkingkooka.validation.form.Form;
 import java.util.Optional;
 import java.util.function.Function;
 
-public class FakeValidatorExpressionEvaluationContext<R extends ValidationReference, S> extends FakeExpressionEvaluationContext implements ValidatorExpressionEvaluationContext<R, S> {
+public class FakeValidatorExpressionEvaluationContext<R extends ValidationReference> extends FakeExpressionEvaluationContext implements ValidatorExpressionEvaluationContext<R> {
 
     public FakeValidatorExpressionEvaluationContext() {
         super();
     }
 
     @Override
-    public ValidatorExpressionEvaluationContext<R, S> enterScope(final Function<ExpressionReference, Optional<Optional<Object>>> scoped) {
+    public ValidatorExpressionEvaluationContext<R> enterScope(final Function<ExpressionReference, Optional<Optional<Object>>> scoped) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/validation/function/ValidatorExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/validation/function/ValidatorExpressionEvaluationContext.java
@@ -25,9 +25,9 @@ import walkingkooka.validation.form.HasForm;
 import java.util.Optional;
 import java.util.function.Function;
 
-public interface ValidatorExpressionEvaluationContext<R extends ValidationReference, S> extends ExpressionEvaluationContext,
+public interface ValidatorExpressionEvaluationContext<R extends ValidationReference> extends ExpressionEvaluationContext,
     HasForm<R> {
 
     @Override
-    ValidatorExpressionEvaluationContext<R, S> enterScope(final Function<ExpressionReference, Optional<Optional<Object>>> function);
+    ValidatorExpressionEvaluationContext<R> enterScope(final Function<ExpressionReference, Optional<Optional<Object>>> function);
 }

--- a/src/main/java/walkingkooka/validation/function/ValidatorExpressionEvaluationContextDelegator.java
+++ b/src/main/java/walkingkooka/validation/function/ValidatorExpressionEvaluationContextDelegator.java
@@ -21,13 +21,13 @@ import walkingkooka.tree.expression.ExpressionEvaluationContextDelegator;
 import walkingkooka.validation.ValidationReference;
 import walkingkooka.validation.form.Form;
 
-public interface ValidatorExpressionEvaluationContextDelegator<R extends ValidationReference, S> extends ValidatorExpressionEvaluationContext<R, S>,
+public interface ValidatorExpressionEvaluationContextDelegator<R extends ValidationReference> extends ValidatorExpressionEvaluationContext<R>,
     ExpressionEvaluationContextDelegator {
 
     // ExpressionEvaluationContextDelegator.............................................................................
 
     @Override
-    ValidatorExpressionEvaluationContext<R, S> expressionEvaluationContext();
+    ValidatorExpressionEvaluationContext<R> expressionEvaluationContext();
 
     // ValidatorExpressionEvaluationContext.............................................................................
 

--- a/src/main/java/walkingkooka/validation/function/ValidatorExpressionEvaluationContextTesting.java
+++ b/src/main/java/walkingkooka/validation/function/ValidatorExpressionEvaluationContextTesting.java
@@ -21,7 +21,7 @@ import walkingkooka.tree.expression.ExpressionEvaluationContextTesting;
 import walkingkooka.validation.ValidationReference;
 import walkingkooka.validation.form.HasFormTesting;
 
-public interface ValidatorExpressionEvaluationContextTesting<R extends ValidationReference, S, C extends ValidatorExpressionEvaluationContext<R, S>> extends ExpressionEvaluationContextTesting<C>,
+public interface ValidatorExpressionEvaluationContextTesting<R extends ValidationReference, C extends ValidatorExpressionEvaluationContext<R>> extends ExpressionEvaluationContextTesting<C>,
     HasFormTesting<R> {
 
     @Override

--- a/src/main/java/walkingkooka/validation/function/ValidatorExpressionEvaluationContexts.java
+++ b/src/main/java/walkingkooka/validation/function/ValidatorExpressionEvaluationContexts.java
@@ -28,7 +28,7 @@ public final class ValidatorExpressionEvaluationContexts implements PublicStatic
     /**
      * {@see FakeValidatorExpressionEvaluationContext}
      */
-    public static <R extends ValidationReference, S> ValidatorExpressionEvaluationContext<R, S> fake() {
+    public static <R extends ValidationReference> ValidatorExpressionEvaluationContext<R> fake() {
         return new FakeValidatorExpressionEvaluationContext<>();
     }
 

--- a/src/test/java/walkingkooka/validation/function/ValidatorExpressionEvaluationContextDelegatorTest.java
+++ b/src/test/java/walkingkooka/validation/function/ValidatorExpressionEvaluationContextDelegatorTest.java
@@ -31,7 +31,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
-public final class ValidatorExpressionEvaluationContextDelegatorTest implements ValidatorExpressionEvaluationContextTesting<TestValidationReference, Void, TestValidatorExpressionEvaluationContextDelegator> {
+public final class ValidatorExpressionEvaluationContextDelegatorTest implements ValidatorExpressionEvaluationContextTesting<TestValidationReference, TestValidatorExpressionEvaluationContextDelegator> {
 
     @Override
     public TestValidatorExpressionEvaluationContextDelegator createContext() {
@@ -97,10 +97,10 @@ public final class ValidatorExpressionEvaluationContextDelegatorTest implements 
         return TestValidatorExpressionEvaluationContextDelegator.class;
     }
 
-    static final class TestValidatorExpressionEvaluationContextDelegator implements ValidatorExpressionEvaluationContextDelegator<TestValidationReference, Void> {
+    static final class TestValidatorExpressionEvaluationContextDelegator implements ValidatorExpressionEvaluationContextDelegator<TestValidationReference> {
 
         @Override
-        public ValidatorExpressionEvaluationContext<TestValidationReference, Void> expressionEvaluationContext() {
+        public ValidatorExpressionEvaluationContext<TestValidationReference> expressionEvaluationContext() {
             return new FakeValidatorExpressionEvaluationContext<>() {
 
                 @Override
@@ -172,7 +172,7 @@ public final class ValidatorExpressionEvaluationContextDelegatorTest implements 
         }
 
         @Override
-        public ValidatorExpressionEvaluationContext<TestValidationReference, Void> enterScope(final Function<ExpressionReference, Optional<Optional<Object>>> function) {
+        public ValidatorExpressionEvaluationContext<TestValidationReference> enterScope(final Function<ExpressionReference, Optional<Optional<Object>>> function) {
             Objects.requireNonNull(function, "function");
 
             return new TestValidatorExpressionEvaluationContextDelegator();

--- a/src/test/java/walkingkooka/validation/function/ValidatorExpressionEvaluationContextTestingTest.java
+++ b/src/test/java/walkingkooka/validation/function/ValidatorExpressionEvaluationContextTestingTest.java
@@ -39,7 +39,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
-public final class ValidatorExpressionEvaluationContextTestingTest implements ValidatorExpressionEvaluationContextTesting<TestValidationReference, Void, TestValidatorExpressionEvaluationContext> {
+public final class ValidatorExpressionEvaluationContextTestingTest implements ValidatorExpressionEvaluationContextTesting<TestValidationReference, TestValidatorExpressionEvaluationContext> {
 
     @Override
     public void testEnterScopeGivesDifferentInstance() {
@@ -98,7 +98,7 @@ public final class ValidatorExpressionEvaluationContextTestingTest implements Va
         return DECIMAL_NUMBER_CONTEXT.positiveSign();
     }
 
-    final static class TestValidatorExpressionEvaluationContext implements ValidatorExpressionEvaluationContext<TestValidationReference, Void> {
+    final static class TestValidatorExpressionEvaluationContext implements ValidatorExpressionEvaluationContext<TestValidationReference> {
 
         @Override
         public TestValidatorExpressionEvaluationContext enterScope(final Function<ExpressionReference, Optional<Optional<Object>>> function) {


### PR DESCRIPTION
- type S is no longer required because of removal of loadXXX saveXXX methods (they are on FormHandlerContext).