### PR TITLE
FormHandlerContext.loadFieldValue Optional<Object> was Optional<?>

### DIFF
--- a/src/main/java/walkingkooka/validation/form/FakeFormHandlerContext.java
+++ b/src/main/java/walkingkooka/validation/form/FakeFormHandlerContext.java
@@ -48,7 +48,7 @@ public class FakeFormHandlerContext<R extends ValidationReference, S> extends Fa
     }
 
     @Override
-    public Optional<?> loadFieldValue(final R reference) {
+    public Optional<Object> loadFieldValue(final R reference) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/validation/form/FormHandlerContext.java
+++ b/src/main/java/walkingkooka/validation/form/FormHandlerContext.java
@@ -144,7 +144,7 @@ public interface FormHandlerContext<R extends ValidationReference, S> extends Ca
      * <br>
      * In a spreadsheet this would use the reference to return the SpreadsheetCell#inputValue assuming the cell is present.
      */
-    Optional<?> loadFieldValue(final R reference);
+    Optional<Object> loadFieldValue(final R reference);
 
     /**
      * Assumes that the fields have been validated, and saves any {@link FormField#value()} ignoring all other field properties.

--- a/src/main/java/walkingkooka/validation/form/FormHandlerContextDelegator.java
+++ b/src/main/java/walkingkooka/validation/form/FormHandlerContextDelegator.java
@@ -51,7 +51,7 @@ public interface FormHandlerContextDelegator<R extends ValidationReference, S> e
     }
 
     @Override
-    default Optional<?> loadFieldValue(final R reference) {
+    default Optional<Object> loadFieldValue(final R reference) {
         return this.formHandlerContext()
             .loadFieldValue(reference);
     }

--- a/src/main/java/walkingkooka/validation/form/FormHandlerContextTesting.java
+++ b/src/main/java/walkingkooka/validation/form/FormHandlerContextTesting.java
@@ -85,7 +85,7 @@ public interface FormHandlerContextTesting<C extends FormHandlerContext<R, S>, R
 
     default void loadFieldValueAndCheck(final C context,
                                         final R reference,
-                                        final Optional<?> expected) {
+                                        final Optional<Object> expected) {
         this.checkEquals(
             expected,
             context.loadFieldValue(reference)

--- a/src/main/java/walkingkooka/validation/form/function/FakeFormHandlerExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/validation/form/function/FakeFormHandlerExpressionEvaluationContext.java
@@ -59,7 +59,7 @@ public class FakeFormHandlerExpressionEvaluationContext<R extends ValidationRefe
     }
 
     @Override
-    public Optional<?> loadFieldValue(final R reference) {
+    public Optional<Object> loadFieldValue(final R reference) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/validation/form/function/FormHandlerExpressionEvaluationContextDelegator.java
+++ b/src/main/java/walkingkooka/validation/form/function/FormHandlerExpressionEvaluationContextDelegator.java
@@ -79,7 +79,7 @@ public interface FormHandlerExpressionEvaluationContextDelegator<R extends Valid
     }
 
     @Override
-    default Optional<?> loadFieldValue(final R reference) {
+    default Optional<Object> loadFieldValue(final R reference) {
         return this.expressionEvaluationContext()
             .loadFieldValue(reference);
     }

--- a/src/test/java/walkingkooka/validation/form/FormHandlerContextDelegatorTest.java
+++ b/src/test/java/walkingkooka/validation/form/FormHandlerContextDelegatorTest.java
@@ -60,7 +60,7 @@ public final class FormHandlerContextDelegatorTest implements FormHandlerContext
                 }
 
                 @Override
-                public Optional<?> loadFieldValue(final TestValidationReference reference) {
+                public Optional<Object> loadFieldValue(final TestValidationReference reference) {
                     Objects.requireNonNull(reference, "reference");
 
                     throw new UnsupportedOperationException();

--- a/src/test/java/walkingkooka/validation/form/FormHandlerContextTestingTest.java
+++ b/src/test/java/walkingkooka/validation/form/FormHandlerContextTestingTest.java
@@ -63,7 +63,7 @@ public final class FormHandlerContextTestingTest implements FormHandlerContextTe
         }
 
         @Override
-        public Optional<?> loadFieldValue(final TestValidationReference reference) {
+        public Optional<Object> loadFieldValue(final TestValidationReference reference) {
             Objects.requireNonNull(reference, "reference");
             throw new UnsupportedOperationException();
         }

--- a/src/test/java/walkingkooka/validation/form/function/FormHandlerExpressionEvaluationContextDelegatorTest.java
+++ b/src/test/java/walkingkooka/validation/form/function/FormHandlerExpressionEvaluationContextDelegatorTest.java
@@ -200,7 +200,7 @@ public final class FormHandlerExpressionEvaluationContextDelegatorTest implement
                 }
 
                 @Override
-                public Optional<?> loadFieldValue(final TestValidationReference reference) {
+                public Optional<Object> loadFieldValue(final TestValidationReference reference) {
                     Objects.requireNonNull(reference, "reference");
 
                     throw new UnsupportedOperationException();

--- a/src/test/java/walkingkooka/validation/form/function/FormHandlerExpressionEvaluationContextTestingTest.java
+++ b/src/test/java/walkingkooka/validation/form/function/FormHandlerExpressionEvaluationContextTestingTest.java
@@ -302,7 +302,7 @@ public final class FormHandlerExpressionEvaluationContextTestingTest implements 
         }
 
         @Override
-        public Optional<?> loadFieldValue(final TestValidationReference reference) {
+        public Optional<Object> loadFieldValue(final TestValidationReference reference) {
             Objects.requireNonNull(reference, "reference");
 
             throw new UnsupportedOperationException();


### PR DESCRIPTION
- Changed return type to match FormField#value.