### PR TITLE
TextMaskValidatorComponent: dash/slash/space mask control characters

### DIFF
--- a/src/main/java/walkingkooka/validation/TextMaskValidatorComponent.java
+++ b/src/main/java/walkingkooka/validation/TextMaskValidatorComponent.java
@@ -57,6 +57,9 @@ abstract class TextMaskValidatorComponent<T extends ValidationReference> impleme
                         case '\\':
                             mode = MODE_BACK_SLASH_ESCAPE;
                             break;
+                        case DASH:
+                            component = character(DASH);
+                            break;
                         case DIGIT:
                             component = digit();
                             break;
@@ -95,6 +98,12 @@ abstract class TextMaskValidatorComponent<T extends ValidationReference> impleme
                                 throw new IllegalArgumentException("Repeating " + CharSequences.quoteIfChars(REPEATING) + ": Missing component before");
                             }
                             component = repeating(component);
+                            break;
+                        case SLASH:
+                            component = character(SLASH);
+                            break;
+                        case SPACE:
+                            component = character(SPACE);
                             break;
                         case UPPER_CASE_LETTER:
                             component = upperCaseLetter();
@@ -224,6 +233,11 @@ abstract class TextMaskValidatorComponent<T extends ValidationReference> impleme
         return components;
     }
 
+    final static char DASH = '-';
+    final static char SLASH = '/';
+    final static char SPACE = ' ';
+
+
     final static char ANY = '?';
 
     /**
@@ -231,6 +245,16 @@ abstract class TextMaskValidatorComponent<T extends ValidationReference> impleme
      */
     static <T extends ValidationReference> TextMaskValidatorComponent<T> any() {
         return TextMaskValidatorComponentCharacterAny.instance();
+    }
+
+    /**
+     * {@link TextMaskValidatorComponentCharacterChar}
+     */
+    static <T extends ValidationReference> TextMaskValidatorComponent<T> character(final char c) {
+        return TextMaskValidatorComponentCharacterChar.with(
+            c,
+            CharSequences.quoteIfChars(c).toString()
+        );
     }
 
     final static char DIGIT = '9';

--- a/src/main/java/walkingkooka/validation/TextMaskValidatorComponentCharacterChar.java
+++ b/src/main/java/walkingkooka/validation/TextMaskValidatorComponentCharacterChar.java
@@ -27,9 +27,45 @@ final class TextMaskValidatorComponentCharacterChar<T extends ValidationReferenc
 
     static <T extends ValidationReference> TextMaskValidatorComponent<T> with(final char c,
                                                                               final String toString) {
-        return new TextMaskValidatorComponentCharacterChar<>(
+        TextMaskValidatorComponentCharacterChar<T> component;
+
+        switch (c) {
+            case DASH:
+                component = DASH_COMPONENT;
+                break;
+            case SLASH:
+                component = SLASH_COMPONENT;
+                break;
+            case SPACE:
+                component = SPACE_COMPONENT;
+                break;
+            default:
+                component = new TextMaskValidatorComponentCharacterChar<>(
+                    c,
+                    toString
+                );
+        }
+
+        return component;
+    }
+
+    private final static TextMaskValidatorComponentCharacterChar DASH_COMPONENT = new TextMaskValidatorComponentCharacterChar<>(
+        DASH
+    );
+
+    private final static TextMaskValidatorComponentCharacterChar SLASH_COMPONENT = new TextMaskValidatorComponentCharacterChar<>(
+        SLASH
+    );
+
+    private final static TextMaskValidatorComponentCharacterChar SPACE_COMPONENT = new TextMaskValidatorComponentCharacterChar<>(
+        SPACE
+    );
+
+    private TextMaskValidatorComponentCharacterChar(final char c) {
+        this(
             c,
-            toString
+            CharSequences.quoteIfChars(c)
+                .toString()
         );
     }
 

--- a/src/test/java/walkingkooka/validation/TextMaskValidatorTest.java
+++ b/src/test/java/walkingkooka/validation/TextMaskValidatorTest.java
@@ -619,6 +619,22 @@ public final class TextMaskValidatorTest implements ValidatorTesting2<TextMaskVa
         );
     }
 
+    @Test
+    public void testValidateWithDashSlashSpace() {
+        this.maskValidateAndCheck(
+            "-/ ",
+            "-/ "
+        );
+    }
+
+    @Test
+    public void testValidateWithDashSlashSpaceLetter() {
+        this.maskValidateAndCheck(
+            "-/ A",
+            "-/ B"
+        );
+    }
+
     private void maskValidateAndCheck(final String mask,
                                       final String text,
                                       final ValidationError<TestValidationReference>...expected) {


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-validation/issues/320
- TextMaskValidator: allow more literals such as DASH, SLASH, currently these must be escaped or within quotes