### PR TITLE
ValidationPromptValue

### DIFF
--- a/src/main/java/walkingkooka/validation/ValidationPromptValue.java
+++ b/src/main/java/walkingkooka/validation/ValidationPromptValue.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.validation;
+
+/**
+ * Interface that tags a value as special within a {@link ValidationError#value()} holding values such {@link ValidationChoiceList}.
+ */
+public interface ValidationPromptValue {
+}


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-validation/issues/381
- ValidationPromptValue: Tag interface marking a ValidationError#value as a value used to prompt the user