### PR TITLE
Validator.promptValue removed

### DIFF
--- a/src/main/java/walkingkooka/validation/AbsoluteUrlValidator.java
+++ b/src/main/java/walkingkooka/validation/AbsoluteUrlValidator.java
@@ -22,7 +22,6 @@ import walkingkooka.net.Url;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * A {@link Validator} that verifies that {@link String} is a {@link AbsoluteUrl}.
@@ -70,14 +69,6 @@ final class AbsoluteUrlValidator<R extends ValidationReference, C extends Valida
         }
 
         return errors;
-    }
-
-    // promptValue......................................................................................................
-
-    @Override
-    public Optional<ValidationPromptValue> promptValue(final ValidatorContext<R> context) {
-        Objects.requireNonNull(context, "context");
-        return NO_PROMPT_VALUES;
     }
 
     // Object...........................................................................................................

--- a/src/main/java/walkingkooka/validation/EmailAddressValidator.java
+++ b/src/main/java/walkingkooka/validation/EmailAddressValidator.java
@@ -21,7 +21,6 @@ import walkingkooka.net.email.EmailAddress;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * A {@link Validator} that verifies that {@link String} is a {@link EmailAddress}.
@@ -69,14 +68,6 @@ final class EmailAddressValidator<R extends ValidationReference, C extends Valid
         }
 
         return errors;
-    }
-
-    // promptValue......................................................................................................
-
-    @Override
-    public Optional<ValidationPromptValue> promptValue(final ValidatorContext<R> context) {
-        Objects.requireNonNull(context, "context");
-        return NO_PROMPT_VALUES;
     }
 
     // Object...........................................................................................................

--- a/src/main/java/walkingkooka/validation/ExpressionValidator.java
+++ b/src/main/java/walkingkooka/validation/ExpressionValidator.java
@@ -22,7 +22,6 @@ import walkingkooka.tree.expression.Expression;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * A {@link Validator} which executes the given {@link Expression} passing the validation value as a reference called VALUE.
@@ -70,17 +69,6 @@ final class ExpressionValidator<R extends ValidationReference, C extends Validat
     }
 
     private final Expression expression;
-
-    // promptValue......................................................................................................
-
-    /**
-     * Note the expression is ignored, and this always returns no choices.
-     */
-    @Override
-    public Optional<ValidationPromptValue> promptValue(final ValidatorContext<R> context) {
-        Objects.requireNonNull(context, "context");
-        return NO_PROMPT_VALUES;
-    }
 
     // Object...........................................................................................................
 

--- a/src/main/java/walkingkooka/validation/FakeValidator.java
+++ b/src/main/java/walkingkooka/validation/FakeValidator.java
@@ -18,7 +18,6 @@
 package walkingkooka.validation;
 
 import java.util.List;
-import java.util.Optional;
 
 public class FakeValidator<R extends ValidationReference, C extends ValidatorContext<R>> implements Validator<R, C> {
 
@@ -29,13 +28,6 @@ public class FakeValidator<R extends ValidationReference, C extends ValidatorCon
     @Override
     public List<ValidationError<R>> validate(final Object value,
                                              final C context) {
-        throw new UnsupportedOperationException();
-    }
-
-    // promptValue......................................................................................................
-
-    @Override
-    public Optional<ValidationPromptValue> promptValue(final ValidatorContext<R> context) {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/walkingkooka/validation/NonNullValidator.java
+++ b/src/main/java/walkingkooka/validation/NonNullValidator.java
@@ -22,7 +22,6 @@ import walkingkooka.collect.list.Lists;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * A {@link Validator} that adds an error if the value is null.
@@ -56,14 +55,6 @@ final class NonNullValidator<R extends ValidationReference, C extends ValidatorC
                     .setMessage("Missing " + context.validationReference())
             ) :
             Lists.empty();
-    }
-
-    // promptValue......................................................................................................
-
-    @Override
-    public Optional<ValidationPromptValue> promptValue(final ValidatorContext<R> context) {
-        Objects.requireNonNull(context, "context");
-        return NO_PROMPT_VALUES;
     }
 
     // Object...........................................................................................................

--- a/src/main/java/walkingkooka/validation/TextLengthValidator.java
+++ b/src/main/java/walkingkooka/validation/TextLengthValidator.java
@@ -21,7 +21,6 @@ import walkingkooka.text.CharSequences;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * A {@link Validator} that assumes a {@link String text} value and verifies its length is between the given range.
@@ -93,14 +92,6 @@ final class TextLengthValidator<R extends ValidationReference, C extends Validat
     private final int minLength;
 
     private final int maxLength;
-
-    // promptValue......................................................................................................
-
-    @Override
-    public Optional<ValidationPromptValue> promptValue(final ValidatorContext<R> context) {
-        Objects.requireNonNull(context, "context");
-        return NO_PROMPT_VALUES;
-    }
 
     // Object...........................................................................................................
 

--- a/src/main/java/walkingkooka/validation/TextMaskValidator.java
+++ b/src/main/java/walkingkooka/validation/TextMaskValidator.java
@@ -26,8 +26,6 @@ import walkingkooka.text.printer.TreePrintable;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
 
 /**
  * A {@link Validator} that supports a mask using the following characters.
@@ -110,14 +108,6 @@ final class TextMaskValidator<R extends ValidationReference, C extends Validator
      * One or more components
      */
     private final List<TextMaskValidatorComponent<R>> components;
-
-    // promptValue......................................................................................................
-
-    @Override
-    public Optional<ValidationPromptValue> promptValue(final ValidatorContext<R> context) {
-        Objects.requireNonNull(context, "context");
-        return NO_PROMPT_VALUES;
-    }
 
     // Object...........................................................................................................
 

--- a/src/main/java/walkingkooka/validation/ValidationCheckboxExpressionValidator.java
+++ b/src/main/java/walkingkooka/validation/ValidationCheckboxExpressionValidator.java
@@ -68,18 +68,6 @@ final class ValidationCheckboxExpressionValidator<R extends ValidationReference,
 
     // choices..........................................................................................................
 
-    /**
-     * Evaluates the {@link Expression} returning the {@link ValidationCheckbox}.
-     */
-    @Override
-    public Optional<ValidationPromptValue> promptValue(final ValidatorContext<R> context) {
-        Objects.requireNonNull(context, "context");
-
-        return Optional.ofNullable(
-            this.evaluateExpressionToValidationCheckbox(context)
-        );
-    }
-
     private ValidationCheckbox evaluateExpressionToValidationCheckbox(final ValidatorContext<R> context) {
         final ExpressionEvaluationContext expressionEvaluationContext = context.expressionEvaluationContext(null);
 

--- a/src/main/java/walkingkooka/validation/ValidationChoiceListExpressionValidator.java
+++ b/src/main/java/walkingkooka/validation/ValidationChoiceListExpressionValidator.java
@@ -77,18 +77,6 @@ final class ValidationChoiceListExpressionValidator<R extends ValidationReferenc
 
     // promptValue......................................................................................................
 
-    /**
-     * Evaluates the {@link Expression} returning the choices {@link ValidationChoiceList}.
-     */
-    @Override
-    public Optional<ValidationPromptValue> promptValue(final ValidatorContext<R> context) {
-        Objects.requireNonNull(context, "context");
-
-        return Optional.ofNullable(
-            this.evaluateExpressionToValidationChoiceList(context)
-        );
-    }
-
     private ValidationChoiceList evaluateExpressionToValidationChoiceList(final ValidatorContext<R> context) {
         final ExpressionEvaluationContext expressionEvaluationContext = context.expressionEvaluationContext(null);
 

--- a/src/main/java/walkingkooka/validation/Validator.java
+++ b/src/main/java/walkingkooka/validation/Validator.java
@@ -18,7 +18,6 @@
 package walkingkooka.validation;
 
 import java.util.List;
-import java.util.Optional;
 
 /**
  * A validator accepts a value and potentially produces {@link ValidationError}.
@@ -37,11 +36,4 @@ public interface Validator<R extends ValidationReference, C extends ValidatorCon
     default ValidationErrorList<R> noValidationErrors() {
         return ValidationErrorList.empty();
     }
-
-    Optional<ValidationPromptValue> NO_PROMPT_VALUES = Optional.empty();
-
-    /**
-     * Some validators may return a {@link ValidationPromptValue} as part of a {@link ValidationError}.
-     */
-    Optional<ValidationPromptValue> promptValue(final ValidatorContext<R> context);
 }

--- a/src/main/java/walkingkooka/validation/ValidatorCollection.java
+++ b/src/main/java/walkingkooka/validation/ValidatorCollection.java
@@ -22,7 +22,6 @@ import walkingkooka.collect.list.Lists;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * A {@link Validator} that contains many other validators, and tries them until the error count exceeds the given {@link #maxErrors}.
@@ -85,14 +84,6 @@ final class ValidatorCollection<R extends ValidationReference, C extends Validat
     private final int maxErrors;
 
     private final List<Validator<R, C>> validators;
-
-    // promptValue......................................................................................................
-
-    @Override
-    public Optional<ValidationPromptValue> promptValue(final ValidatorContext<R> context) {
-        Objects.requireNonNull(context, "context");
-        return NO_PROMPT_VALUES;
-    }
 
     // Object...........................................................................................................
 

--- a/src/main/java/walkingkooka/validation/ValidatorTesting.java
+++ b/src/main/java/walkingkooka/validation/ValidatorTesting.java
@@ -17,11 +17,9 @@
 
 package walkingkooka.validation;
 
-import walkingkooka.collect.list.Lists;
 import walkingkooka.test.Testing;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface ValidatorTesting extends Testing {
 
@@ -47,46 +45,6 @@ public interface ValidatorTesting extends Testing {
                 value,
                 context
             )
-        );
-    }
-
-    default <R extends ValidationReference, C extends ValidatorContext<R>> void promptValueAndCheck(final Validator<R, C> validator,
-                                                                                                    final C context) {
-        this.promptValueAndCheck(
-            validator,
-            context,
-            Optional.empty()
-        );
-    }
-
-    default <R extends ValidationReference, C extends ValidatorContext<R>> void promptValueAndCheck(final Validator<R, C> validator,
-                                                                                                    final C context,
-                                                                                                    final ValidationChoice... expected) {
-        this.promptValueAndCheck(
-            validator,
-            context,
-            ValidationChoiceList.EMPTY.setElements(
-                Lists.of(expected)
-            )
-        );
-    }
-
-    default <R extends ValidationReference, C extends ValidatorContext<R>> void promptValueAndCheck(final Validator<R, C> validator,
-                                                                                                    final C context,
-                                                                                                    final ValidationPromptValue expected) {
-        this.promptValueAndCheck(
-            validator,
-            context,
-            Optional.of(expected)
-        );
-    }
-
-    default <R extends ValidationReference, C extends ValidatorContext<R>> void promptValueAndCheck(final Validator<R, C> validator,
-                                                                                                    final C context,
-                                                                                                    final Optional<ValidationPromptValue> expected) {
-        this.checkEquals(
-            expected,
-            validator.promptValue(context)
         );
     }
 }

--- a/src/main/java/walkingkooka/validation/ValidatorTesting2.java
+++ b/src/main/java/walkingkooka/validation/ValidatorTesting2.java
@@ -18,7 +18,6 @@
 package walkingkooka.validation;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.collect.list.Lists;
 
 import java.util.List;
 
@@ -56,52 +55,6 @@ public interface ValidatorTesting2<V extends Validator<R, C>, R extends Validati
         this.validateAndCheck(
             this.createValidator(),
             value,
-            context,
-            expected
-        );
-    }
-
-    // promptValue......................................................................................................
-
-    @Test
-    default void testPromptValueWithNullContextFails() {
-        assertThrows(
-            NullPointerException.class,
-            () -> this.createValidator()
-                .promptValue(
-                    null
-                )
-        );
-    }
-
-    default void promptValueAndCheck(final ValidationChoice... expected) {
-        this.promptValueAndCheck(
-            this.createContext(),
-            expected
-        );
-    }
-
-    default void promptValueAndCheck(final ValidationPromptValue expected) {
-        this.promptValueAndCheck(
-            this.createContext(),
-            expected
-        );
-    }
-
-    default void promptValueAndCheck(final C context,
-                                     final ValidationChoice... expected) {
-        this.promptValueAndCheck(
-            context,
-            ValidationChoiceList.EMPTY.setElements(
-                Lists.of(expected)
-            )
-        );
-    }
-
-    default void promptValueAndCheck(final C context,
-                                     final ValidationPromptValue expected) {
-        this.promptValueAndCheck(
-            this.createValidator(),
             context,
             expected
         );

--- a/src/test/java/walkingkooka/validation/ValidatorTesting2Test.java
+++ b/src/test/java/walkingkooka/validation/ValidatorTesting2Test.java
@@ -18,13 +18,11 @@
 package walkingkooka.validation;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.validation.ValidatorTesting2Test.TestValidator;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 public class ValidatorTesting2Test implements ValidatorTesting2<TestValidator, TestValidationReference, TestValidatorContext> {
 
@@ -44,22 +42,6 @@ public class ValidatorTesting2Test implements ValidatorTesting2<TestValidator, T
             new TestValidatorContext(),
             error1,
             error2
-        );
-    }
-
-    private final static Optional<ValidationChoiceList> CHOICES = Optional.of(
-        ValidationChoiceList.EMPTY.concat(
-            ValidationChoice.with(
-                "Label1",
-                Optional.of(1)
-            )
-        )
-    );
-
-    @Test
-    public void testChoices() {
-        this.promptValueAndCheck(
-            CHOICES.get()
         );
     }
 
@@ -87,14 +69,5 @@ public class ValidatorTesting2Test implements ValidatorTesting2<TestValidator, T
         }
 
         private final List<ValidationError<TestValidationReference>> errors;
-
-        // promptValue..................................................................................................
-
-        @Override
-        public Optional<ValidationPromptValue> promptValue(final ValidatorContext<TestValidationReference> context) {
-            Objects.requireNonNull(context, "context");
-
-            return Cast.to(CHOICES);
-        }
     }
 }


### PR DESCRIPTION
- Unnecessary to have a public getter, as ValidationPromptValues can be returned in the ValidationErrorList.